### PR TITLE
Include license file in wheels and sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include LICENSE
+include README.md
+include tox.ini

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,6 @@ universal = 1
 max-line-length = 140
 ignore = E402,E731
 exclude = .git,__pycache__,.tox,docs,tests,build,dist,examples
+
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
The license requires that all copies of the software include the license text.  These patches make sure sdists and wheels include the license text.  Without this, other people cannot legally redistribute the software.