### PR TITLE
added projekt home page url

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     license='MIT',
     author='Irmen de Jong',
     author_email='irmen@razorvine.net',
+    url='https://github.com/irmen/Serpent',
     description='Serialization based on ast.literal_eval',
     long_description="""
 Serpent is a simple serialization library based on ast.literal_eval.


### PR DESCRIPTION
Hi @irmen,

by adding this URL PyPi will host a link to your github.

Like this: 
![grafik](https://user-images.githubusercontent.com/43759631/69952831-4af16380-14f8-11ea-91e5-068098f7f8ec.png)


What do you think?