### PR TITLE
Let PEP 503 compliant pypi servers not install us to old python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
     name='serpent',
     version=serpent_version,
     py_modules=["serpent"],
+    python_requires='>=3.2',
     license='MIT',
     author='Irmen de Jong',
     author_email='irmen@razorvine.net',


### PR DESCRIPTION
This means that instead of failing to install, pip will pick an older package version.